### PR TITLE
Create dictionaries for NWB export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.1.0b1] - 2022-01-13
+## [0.1.0b1] - 2022-01-28
 ### Added
 + Added functions to generate dictionaries for NWB export.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.0b1] - 2022-01-13
+### Added
++ Tools to generate dictionaries for NWB export
+
+
 ## [0.1.0b0] - 2021-05-07
 ### Added
 + First beta release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 ## [0.1.0b1] - 2022-01-13
 ### Added
-+ Tools to generate dictionaries for NWB export
++ Added functions to generate dictionaries for NWB export.
 
 
 ## [0.1.0b0] - 2021-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,6 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Added GitHub Action release process
 + Added `lab` schema
 
-
+[0.1.0b1]: https://github.com/datajoint/element-lab/compare/0.1.0b0...0.1.0b1
 [0.1.0b0]: https://github.com/datajoint/element-lab/compare/0.1.0a1...0.1.0b0
 [0.1.0a1]: https://github.com/datajoint/element-lab/releases/tag/0.1.0a1

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ARG PKG_NAME
 ARG PKG_VERSION
 
 FROM datajoint/${IMAGE}:py${PY_VER}-${DISTRO}
-COPY --chown=dja:anaconda ./requirements.txt ./setup.py \
+COPY --chown=anaconda:anaconda ./requirements.txt ./setup.py \
     /main/
-COPY --chown=dja:anaconda ./${PKG_NAME} /main/${PKG_NAME}
+COPY --chown=anaconda:anaconda ./${PKG_NAME} /main/${PKG_NAME}
 RUN \
     cd /main && \
     pip install . && \

--- a/element_lab/__init__.py
+++ b/element_lab/__init__.py
@@ -1,4 +1,4 @@
 __author__ = "DataJoint"
 __date__ = "December, 2021"
-__version__ = "0.1.0b0"
+__version__ = "0.1.0b1"
 __all__ = ['__author__', '__version__', '__date__']

--- a/element_lab/__init__.py
+++ b/element_lab/__init__.py
@@ -1,4 +1,4 @@
-__author__ = "DataJoint NEURO"
+__author__ = "DataJoint"
 __date__ = "December, 2021"
 __version__ = "0.1.0b0"
 __all__ = ['__author__', '__version__', '__date__']

--- a/element_lab/__init__.py
+++ b/element_lab/__init__.py
@@ -1,4 +1,0 @@
-__author__ = "DataJoint"
-__date__ = "December, 2021"
-__version__ = "0.1.0b1"
-__all__ = ['__author__', '__version__', '__date__']

--- a/element_lab/__init__.py
+++ b/element_lab/__init__.py
@@ -1,4 +1,4 @@
 __author__ = "DataJoint NEURO"
-__date__ = "December 15, 2020"
-__version__ = "0.0.1"
+__date__ = "December, 2021"
+__version__ = "0.1.0b0"
 __all__ = ['__author__', '__version__', '__date__']

--- a/element_lab/export/__init__.py
+++ b/element_lab/export/__init__.py
@@ -1,1 +1,1 @@
-from .nwb import lab_to_nwb
+from .nwb import *

--- a/element_lab/export/__init__.py
+++ b/element_lab/export/__init__.py
@@ -1,0 +1,1 @@
+from .nwb import lab_to_nwb

--- a/element_lab/export/__init__.py
+++ b/element_lab/export/__init__.py
@@ -1,1 +1,1 @@
-from .nwb import *
+from .nwb import elementlab_nwb_dict

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -1,13 +1,6 @@
 from datetime import datetime
 from element_lab import lab
 
-'''
-Broz 120121: packages lab, project and protocol data as dicts
-    Updated session nwb export function then reads items
-    if they exist, populates. If not, blank - not best practice.
-    How to populate only NWB items for which we have user entries?
-'''
-
 def lab_to_nwb_dict(lab_key=None):
     if lab_key is not None:
         lab_info = (lab.Lab & lab_key).fetch1()
@@ -36,12 +29,16 @@ def proj_to_nwb_dict(project_key=None):
                 if 'slices' in proj_info else ''),
             source_script=(proj_info['repositoryurl']
                 if 'repositoryurl' in proj_info else ''),
-            stimulus=(list(proj_info['stimulus'])
-                if 'stimulus' in proj_info else []),
             surgery=(proj_info['surgery']
                 if 'surgery' in proj_info else ''),
             virus=(proj_info['virus']
                 if 'virus' in proj_info else '')
+
+            ## AttributeError: 'str' object has no attribute 'parent'
+            ## Broz: I thought these were notes about the stimulus?
+            ##    Error indicates trying to process stim file itself?
+            # stimulus=(list(proj_info['stimulus'])
+            #     if 'stimulus' in proj_info else [])
         )
     else: return {}
 
@@ -59,10 +56,14 @@ def prot_to_nwb_dict(protocol_key=None):
     else: return {}
 
 def elemlab_to_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
-    return dict(
+    elem_info=dict(
         lab_to_nwb_dict(lab_key),
         **proj_to_nwb_dict(project_key),
         **prot_to_nwb_dict(protocol_key)
         )
+    for k in list(elem_info): # Drop blank entries
+        if len(elem_info[k]) == 0: elem_info.pop(k)
+    return elem_info
+
 
 

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -76,17 +76,12 @@ def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
     """
     # Validate input
     if lab_key is not None: 
-        assert len(lab.Lab & lab_key
-                   ) == 1, ('Multiple labs error! The lab_key should specify '
-                            + 'only one lab.')
-    if project_key is not None:
-        assert len(lab.Project & project_key
-                   ) == 1, ('Multiple projects error! The project_key should'
-                            + ' specify only one project.')
-    if protocol_key is not None:
-        assert len(lab.Protocol & protocol_key
-                   ) == 1, ('Multiple protocols error! The protocol_key should'
-                            + ' specify only one protocol.')
+        assert len(lab.Lab & lab_key) == 1,  'Multiple labs error! '\
+            'The lab_key should specify only one lab.'
+    assert project_key is None or len(lab.Project & project_key) == 1, \
+        'Multiple projects error! The project_key should specify only one project.'
+    assert protocol_key is None or len(lab.Protocol & protocol_key) == 1, \
+        'Multiple protocols error! protocol_key should specify only one protocol.'
 
     elem_info = dict(
         lab_to_nwb_dict(lab_key),
@@ -95,8 +90,6 @@ def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
         )
 
     # Drop blank entries
-    for k in list(elem_info):
-        if len(elem_info[k]) == 0:
-            elem_info.pop(k)
+    elem_info = {k: v for k, v in elem_info.items() if v}
 
     return elem_info

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -10,7 +10,8 @@ def lab_to_nwb_dict(lab_key):
     lab_info = (lab.Lab & lab_key).fetch1()
     return dict(
         institution=lab_info.get('institution', ''),
-        lab=lab_info.get('lab_name', '')
+        lab=lab_info.get('lab_name', ''),
+        time_zone=lab_info.get('time_zone', ''),
     )
 
 

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -1,21 +1,20 @@
-from datetime import datetime
 from element_lab import lab
+
 
 def lab_to_nwb_dict(lab_key=None):
     """
-    Generate a dictionary object containing all relevant lab and institution information.
+    Generate a dictionary containing all relevant lab and institution info
     :param lab_key: Key specifying one entry in element_lab.lab.Lab
     :return: dictionary with NWB parameters
     """
     if lab_key is not None:
         lab_info = (lab.Lab & lab_key).fetch1()
         return dict(
-            institution=(lab_info['institution']
-                if 'institution' in lab_info else ''),
-            lab=(lab_info['lab_name']
-                if 'lab_name' in lab_info else '')
+            institution=lab_info.get('institution', ''),
+            lab=lab_info.get('lab_name', '')
         )
-    else: return {}
+    else:
+        return {}
 
 
 def project_to_nwb_dict(project_key=None):
@@ -27,19 +26,17 @@ def project_to_nwb_dict(project_key=None):
     """
     if project_key is not None:
         proj_info = (lab.Project & project_key).fetch1()
-        proj_keyw = (lab.Project.Keywords() & project_key).fetch('keyword').tolist()
-        proj_pubs = (lab.Project.Publication() & project_key).fetch('publication').tolist()
+        proj_keyw = (lab.Project.Keywords() & project_key
+                     ).fetch('keyword').tolist()
+        proj_pubs = (lab.Project.Publication() & project_key
+                     ).fetch('publication').tolist()
         return dict(
-            experiment_description=(proj_info.get('project_description', ''),
+            experiment_description=(proj_info.get('project_description', '')),
             keywords=proj_keyw,
-            pharmacology=proj_info.get('pharmacology', ''),
-            related_publications=proj_pubs,
-            slices=proj_info.get('slices', ''),
-            source_script=proj_info.get('repositoryurl', ''),
-            surgery=(proj_info.get('surgery', ''),
-            virus=proj_info.get('virus', '')
+            related_publications=proj_pubs
         )
-    else: return {}
+    else:
+        return {}
 
 
 def protocol_to_nwb_dict(protocol_key=None):
@@ -53,45 +50,53 @@ def protocol_to_nwb_dict(protocol_key=None):
         return dict(
             # data_collection='',
             protocol=(prot_info['protocol']
-                if 'protocol' in prot_info else ''),
+                      if 'protocol' in prot_info else ''),
             notes=(prot_info['protocol_description']
-                if 'project_description' in prot_info else '')
+                   if 'project_description' in prot_info else '')
         )
-    else: return {}
+    else:
+        return {}
 
-def elementlab_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
+
+def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
     """
-    Generate a dictionary object containing all relevant lab information used when
-        generating an NWB file at the session level. All parameters optional.
+    Generate a dictionary object containing all relevant lab information used
+        when generating an NWB file at the session level.
+        All parameters optional, but should only specify one of respective type
     Use: mynwbfile = NWBfile(identifier="your identifier",
                              session_description="your description",
                              session_start_time=session_datetime,
-                             elementlab_nwb_dict(lab_key=key1,project_key=key2,protocol_key=key3))
-    Note: The lab, project and protocol keys should specify one of their respective types.
+                             elementlab_nwb_dict(lab_key=key1,project_key=key2,
+                                                 protocol_key=key3))
 
     :param lab_key: Key specifying one entry in element_lab.lab.Lab
     :param project_key: Key specifying one entry in element_lab.lab.Project
     :param protocol_key: Key specifying one entry in element_lab.lab.PRotocol
     :return: dictionary with NWB parameters
     """
-    ## Validate input
+    # Validate input
     if lab_key is not None: 
-        assert len(lab.Lab & lab_key) == 1, 'Multiple labs error! The lab_key should specify only one lab.'
-    if project_key is not None: assert len(lab.Project & project_key) == 1, \
-        f'Multiple projects error! The project_key should specify only one project.'
-    if protocol_key is not None: assert len(lab.Protocol & protocol_key) == 1, \
-        f'Multiple protocols error! The protocol_key should specify only one protocol.'
+        assert len(lab.Lab & lab_key
+                   ) == 1, ('Multiple labs error! The lab_key should specify '
+                            + 'only one lab.')
+    if project_key is not None:
+        assert len(lab.Project & project_key
+                   ) == 1, ('Multiple projects error! The project_key should'
+                            + ' specify only one project.')
+    if protocol_key is not None:
+        assert len(lab.Protocol & protocol_key
+                   ) == 1, ('Multiple protocols error! The protocol_key should'
+                            + ' specify only one protocol.')
 
-    elem_info=dict(
+    elem_info = dict(
         lab_to_nwb_dict(lab_key),
         **project_to_nwb_dict(project_key),
         **protocol_to_nwb_dict(protocol_key)
         )
 
-    for k in list(elem_info): # Drop blank entries
-        if len(elem_info[k]) == 0: elem_info.pop(k)
+    # Drop blank entries
+    for k in list(elem_info):
+        if len(elem_info[k]) == 0:
+            elem_info.pop(k)
 
     return elem_info
-
-
-

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -1,31 +1,68 @@
-import numpy as np
 from datetime import datetime
-from dateutil.tz import tzlocal
-from pynwb import NWBFile
-
 from element_lab import lab
 
-def lab_to_nwb(lab_key):
-    lab_query = lab.Lab & lab_key
-    lab_query = lab_query.join(lab.Lab.Protocol, left=True)
-    lab_query = lab_query.join(lab.Lab.Project, left=True)
-    lab_info = lab.query.fetch1()
+'''
+Broz 120121: packages lab, project and protocol data as dicts
+    Updated session nwb export function then reads items
+    if they exist, populates. If not, blank - not best practice.
+    How to populate only NWB items for which we have user entries?
+'''
 
-    return NWBFile(
-    data_collection='',
-    experiment_description=lab_info.pop('project_description'),
-    institution=lab_info.pop('institution'),
-    keywords=list(lab.Project.keywords.fetch()),
-    lab=lab_info.pop('lab_name'),
-    notes=lab_info.pop('protocol_description'),
-    pharmacology=lab_info.pop('pharmacology'),
-    protocol=lab_info.pop('protocol'),
-    related_publications=list(lab.Project.publication.fetch()),
-    session_id='', # why is NWB asking for this at this level?
-    slices=lab_info.pop('slices'),
-    souce_script=lab_info.pop('repositoryurl'),
-    file_name=lab_info.pop('repositoryname'),
-    stimulus=lab_info.pop('stimulus'),
-    surgery=lab_info.pop('surgery'),
-    virus=lab_info.pop('virus')
-    )
+def lab_to_nwb_dict(lab_key=None):
+    if lab_key is not None:
+        lab_info = (lab.Lab & lab_key).fetch1()
+        return dict(
+            institution=(lab_info['institution']
+                if 'institution' in lab_info else ''),
+            lab=(lab_info['lab_name']
+                if 'lab_name' in lab_info else '')
+        )
+    else: return {}
+
+
+def proj_to_nwb_dict(project_key=None):
+    if project_key is not None:
+        proj_info = (lab.Project & project_key).fetch1()
+        proj_keyw = (lab.Project.Keywords() & project_key).fetch('keyword').tolist()
+        proj_pubs = (lab.Project.Publication() & project_key).fetch('publication').tolist()
+        return dict(
+            experiment_description=(proj_info['project_description']
+                if 'project_description' in proj_info else ''),
+            keywords=proj_keyw,
+            pharmacology=(proj_info['pharmacology']
+                if 'pharmacology' in proj_info else ''),
+            related_publications=proj_pubs,
+            slices=(proj_info['slices']
+                if 'slices' in proj_info else ''),
+            source_script=(proj_info['repositoryurl']
+                if 'repositoryurl' in proj_info else ''),
+            stimulus=(list(proj_info['stimulus'])
+                if 'stimulus' in proj_info else []),
+            surgery=(proj_info['surgery']
+                if 'surgery' in proj_info else ''),
+            virus=(proj_info['virus']
+                if 'virus' in proj_info else '')
+        )
+    else: return {}
+
+
+def prot_to_nwb_dict(protocol_key=None):
+    if protocol_key is not None:
+        prot_info = (lab.Protocol & protocol_key).fetch1()
+        return dict(
+            # data_collection='',
+            protocol=(prot_info['protocol']
+                if 'protocol' in prot_info else ''),
+            notes=(prot_info['protocol_description']
+                if 'project_description' in prot_info else '')
+        )
+    else: return {}
+
+def elemlab_to_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
+    return dict(
+        lab_to_nwb_dict(lab_key),
+        **proj_to_nwb_dict(project_key),
+        **prot_to_nwb_dict(protocol_key)
+        )
+
+

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -24,8 +24,9 @@ def project_to_nwb_dict(project_key):
     project_info = (lab.Project & project_key).fetch1()
     return dict(
         experiment_description=project_info.get('project_description'),
-        keywords=(lab.Keywords() & project_key).fetch('keyword').tolist() or None,
-        related_publications=(lab.Publication() & project_key
+        keywords=(lab.ProjectKeywords() & project_key
+                  ).fetch('keyword').tolist() or None,
+        related_publications=(lab.ProjectPublication() & project_key
                               ).fetch('publication').tolist() or None
     )
 

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -49,10 +49,10 @@ def element_lab_to_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
     Generate a dictionary object containing all relevant lab information used
         when generating an NWB file at the session level.
         All parameters optional, but should only specify one of respective type
-    Use: mynwbfile = NWBfile(identifier="your identifier",
+    Use: mynwbfile = pynwb.NWBFile(identifier="your identifier",
                              session_description="your description",
                              session_start_time=session_datetime,
-                             **elementlab_nwb_dict(
+                             **element_lab_to_nwb_dict(
                                 lab_key=key1,
                                 project_key=key2,
                                 protocol_key=key3))

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -77,8 +77,8 @@ def elementlab_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
     :return: dictionary with NWB parameters
     """
     ## Validate input
-    if lab_key is not None: assert len(lab.Lab & lab_key) == 1, \
-        f'Multiple labs error! The lab_key should specify only one lab.'
+    if lab_key is not None: 
+        assert len(lab.Lab & lab_key) == 1, 'Multiple labs error! The lab_key should specify only one lab.'
     if project_key is not None: assert len(lab.Project & project_key) == 1, \
         f'Multiple projects error! The project_key should specify only one project.'
     if protocol_key is not None: assert len(lab.Protocol & protocol_key) == 1, \

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -6,12 +6,12 @@ from pynwb import NWBFile
 from element_lab import lab
 
 def lab_to_nwb(lab_key):
-  lab_query = lab.Lab & lab_key
+    lab_query = lab.Lab & lab_key
     lab_query = lab_query.join(lab.Lab.Protocol, left=True)
     lab_query = lab_query.join(lab.Lab.Project, left=True)
-  lab_info = lab.query.fetch1()
+    lab_info = lab.query.fetch1()
 
-  return NWBFile(
+    return NWBFile(
     data_collection='',
     experiment_description=lab_info.pop('project_description'),
     institution=lab_info.pop('institution'),

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -21,9 +21,9 @@ def project_to_nwb_dict(project_key):
     :param project_key: Key specifying one entry in element_lab.lab.Project
     :return: dictionary with NWB parameters
     """
-    proj_info = (lab.Project & project_key).fetch1()
+    project_info = (lab.Project & project_key).fetch1()
     return dict(
-        experiment_description=proj_info.get('project_description'),
+        experiment_description=project_info.get('project_description'),
         keywords=(lab.Project.Keywords() & project_key).fetch('keyword').tolist() or None,
         related_publications=(lab.Project.Publication() & project_key).fetch('publication').tolist() or None
     )
@@ -35,14 +35,14 @@ def protocol_to_nwb_dict(protocol_key):
     :param protocol_key: Key specifying one entry in element_lab.lab.Protocol
     :return: dictionary with NWB parameters
     """
-    prot_info = (lab.Protocol & protocol_key).fetch1()
+    protocol_info = (lab.Protocol & protocol_key).fetch1()
     return dict(
-        protocol=prot_info.get('protocol'),
-        notes=prot_info.get('protocol_description')
+        protocol=protocol_info.get('protocol'),
+        notes=protocol_info.get('protocol_description')
     )
 
 
-def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
+def element_lab_to_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
     """
     Generate a dictionary object containing all relevant lab information used
         when generating an NWB file at the session level.
@@ -59,7 +59,7 @@ def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
 
     :param lab_key: Key specifying one entry in element_lab.lab.Lab
     :param project_key: Key specifying one entry in element_lab.lab.Project
-    :param protocol_key: Key specifying one entry in element_lab.lab.PRotocol
+    :param protocol_key: Key specifying one entry in element_lab.lab.Protocol
     :return: dictionary with NWB parameters
     """
     # Validate input
@@ -70,15 +70,15 @@ def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
         'Multiple projects error! The project_key should specify only one '\
         'project.'
     assert protocol_key is None or len(lab.Protocol & protocol_key) == 1, \
-        'Multiple protocols error! protocol_key should specify only one '\
+        'Multiple protocols error! The protocol_key should specify only one '\
         'protocol.'
 
-    elem_info = dict()
+    element_info = dict()
     if lab_key:
-        elem_info.update(lab_to_nwb_dict(lab_key))
+        element_info.update(lab_to_nwb_dict(lab_key))
     if project_key:
-        elem_info.update(project_to_nwb_dict(project_key))
+        element_info.update(project_to_nwb_dict(project_key))
     if protocol_key:
-        elem_info.update(protocol_to_nwb_dict(protocol_key))
+        element_info.update(protocol_to_nwb_dict(protocol_key))
 
-    return elem_info
+    return element_info

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -1,7 +1,11 @@
 from datetime import datetime
-from element_lab import lab
 
 def lab_to_nwb_dict(lab_key=None):
+    """
+    Generate a dictionary object containing all relevant lab and institution information.
+    :param lab_key: Key specifying one entry in element_lab.lab.Lab
+    :return: dictionary with NWB parameters
+    """
     if lab_key is not None:
         lab_info = (lab.Lab & lab_key).fetch1()
         return dict(
@@ -14,6 +18,12 @@ def lab_to_nwb_dict(lab_key=None):
 
 
 def proj_to_nwb_dict(project_key=None):
+    """
+    Generate a dictionary object containing relevant project information
+        (e.g., experimental description, related publications, etc.).
+    :param project_key: Key specifying one entry in element_lab.lab.Project
+    :return: dictionary with NWB parameters
+    """
     if project_key is not None:
         proj_info = (lab.Project & project_key).fetch1()
         proj_keyw = (lab.Project.Keywords() & project_key).fetch('keyword').tolist()
@@ -44,6 +54,11 @@ def proj_to_nwb_dict(project_key=None):
 
 
 def prot_to_nwb_dict(protocol_key=None):
+    """
+    Generate a dictionary object containing all protocol title and notes.
+    :param protocol_key: Key specifying one entry in element_lab.lab.Protocol
+    :return: dictionary with NWB parameters
+    """
     if protocol_key is not None:
         prot_info = (lab.Protocol & protocol_key).fetch1()
         return dict(
@@ -56,13 +71,37 @@ def prot_to_nwb_dict(protocol_key=None):
     else: return {}
 
 def elemlab_to_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
+    """
+    Generate a dictionary object containing all relevant lab information used when
+        generating an NWB file at the session level. All parameters optional.
+    Use: mynwbfile = NWBfile(identifier="your identifier",
+                             session_description="your description",
+                             session_start_time=session_datetime,
+                             elemlab_to_nwb_dict(lab_key=key1,project_key=key2,protocol_key=key3))
+    Note: The lab, project and protocol keys should specify one of their respective types.
+
+    :param lab_key: Key specifying one entry in element_lab.lab.Lab
+    :param project_key: Key specifying one entry in element_lab.lab.Project
+    :param protocol_key: Key specifying one entry in element_lab.lab.PRotocol
+    :return: dictionary with NWB parameters
+    """
+    ## Validate input
+    if lab_key is not None: assert len(lab.Lab & lab_key) == 1, \
+        f'Multiple labs error! The lab_key should specify only one lab.'
+    if project_key is not None: assert len(lab.Project & project_key) == 1, \
+        f'Multiple projects error! The project_key should specify only one project.'
+    if protocol_key is not None: assert len(lab.Protocol & protocol_key) == 1, \
+        f'Multiple protocols error! The protocol_key should specify only one protocol.'
+
     elem_info=dict(
         lab_to_nwb_dict(lab_key),
         **proj_to_nwb_dict(project_key),
         **prot_to_nwb_dict(protocol_key)
         )
+
     for k in list(elem_info): # Drop blank entries
         if len(elem_info[k]) == 0: elem_info.pop(k)
+
     return elem_info
 
 

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -32,8 +32,7 @@ def project_to_nwb_dict(project_key=None):
         return dict(
             experiment_description=(proj_info.get('project_description', ''),
             keywords=proj_keyw,
-            pharmacology=(proj_info['pharmacology']
-                if 'pharmacology' in proj_info else ''),
+            pharmacology=proj_info.get('pharmacology', ''),
             related_publications=proj_pubs,
             slices=(proj_info['slices']
                 if 'slices' in proj_info else ''),

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -1,61 +1,52 @@
 from element_lab import lab
 
 
-def lab_to_nwb_dict(lab_key=None):
+def lab_to_nwb_dict(lab_key):
     """
     Generate a dictionary containing all relevant lab and institution info
     :param lab_key: Key specifying one entry in element_lab.lab.Lab
     :return: dictionary with NWB parameters
     """
-    if lab_key is not None:
-        lab_info = (lab.Lab & lab_key).fetch1()
-        return dict(
-            institution=lab_info.get('institution', ''),
-            lab=lab_info.get('lab_name', '')
-        )
-    else:
-        return {}
+    lab_info = (lab.Lab & lab_key).fetch1()
+    return dict(
+        institution=lab_info.get('institution', ''),
+        lab=lab_info.get('lab_name', '')
+    )
 
 
-def project_to_nwb_dict(project_key=None):
+def project_to_nwb_dict(project_key):
     """
     Generate a dictionary object containing relevant project information
         (e.g., experimental description, related publications, etc.).
     :param project_key: Key specifying one entry in element_lab.lab.Project
     :return: dictionary with NWB parameters
     """
-    if project_key is not None:
-        proj_info = (lab.Project & project_key).fetch1()
-        proj_keyw = (lab.Project.Keywords() & project_key
-                     ).fetch('keyword').tolist()
-        proj_pubs = (lab.Project.Publication() & project_key
-                     ).fetch('publication').tolist()
-        return dict(
-            experiment_description=(proj_info.get('project_description', '')),
-            keywords=proj_keyw,
-            related_publications=proj_pubs
-        )
-    else:
-        return {}
+    proj_info = (lab.Project & project_key).fetch1()
+    proj_keyw = (lab.Project.Keywords() & project_key
+                 ).fetch('keyword').tolist()
+    proj_pubs = (lab.Project.Publication() & project_key
+                 ).fetch('publication').tolist()
+    return dict(
+        experiment_description=(proj_info.get('project_description', '')),
+        keywords=proj_keyw,
+        related_publications=proj_pubs
+    )
 
 
-def protocol_to_nwb_dict(protocol_key=None):
+def protocol_to_nwb_dict(protocol_key):
     """
     Generate a dictionary object containing all protocol title and notes.
     :param protocol_key: Key specifying one entry in element_lab.lab.Protocol
     :return: dictionary with NWB parameters
     """
-    if protocol_key is not None:
-        prot_info = (lab.Protocol & protocol_key).fetch1()
-        return dict(
-            # data_collection='',
-            protocol=(prot_info['protocol']
-                      if 'protocol' in prot_info else ''),
-            notes=(prot_info['protocol_description']
-                   if 'project_description' in prot_info else '')
-        )
-    else:
-        return {}
+    prot_info = (lab.Protocol & protocol_key).fetch1()
+    return dict(
+        # data_collection='',
+        protocol=(prot_info['protocol']
+                  if 'protocol' in prot_info else ''),
+        notes=(prot_info['protocol_description']
+               if 'project_description' in prot_info else '')
+    )
 
 
 def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
@@ -75,19 +66,23 @@ def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
     :return: dictionary with NWB parameters
     """
     # Validate input
-    if lab_key is not None: 
-        assert len(lab.Lab & lab_key) == 1,  'Multiple labs error! '\
-            'The lab_key should specify only one lab.'
+    assert any([lab_key, project_key, protocol_key]), 'Must specify one key.'
+    assert lab_key is None or len(lab.Lab & lab_key) == 1, \
+        'Multiple labs error! The lab_key should specify only one lab.'
     assert project_key is None or len(lab.Project & project_key) == 1, \
-        'Multiple projects error! The project_key should specify only one project.'
+        'Multiple projects error! The project_key should specify only one '\
+        'project.'
     assert protocol_key is None or len(lab.Protocol & protocol_key) == 1, \
-        'Multiple protocols error! protocol_key should specify only one protocol.'
+        'Multiple protocols error! protocol_key should specify only one '\
+        'protocol.'
 
-    elem_info = dict(
-        lab_to_nwb_dict(lab_key),
-        **project_to_nwb_dict(project_key),
-        **protocol_to_nwb_dict(protocol_key)
-        )
+    elem_info = dict()
+    if lab_key:
+        elem_info.update(**lab_to_nwb_dict(lab_key))
+    if project_key:
+        elem_info.update(**project_to_nwb_dict(project_key))
+    if protocol_key:
+        elem_info.update(**protocol_to_nwb_dict(protocol_key))
 
     # Drop blank entries
     elem_info = {k: v for k, v in elem_info.items() if v}

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -24,8 +24,9 @@ def project_to_nwb_dict(project_key):
     project_info = (lab.Project & project_key).fetch1()
     return dict(
         experiment_description=project_info.get('project_description'),
-        keywords=(lab.Project.Keywords() & project_key).fetch('keyword').tolist() or None,
-        related_publications=(lab.Project.Publication() & project_key).fetch('publication').tolist() or None
+        keywords=(lab.Keywords() & project_key).fetch('keyword').tolist() or None,
+        related_publications=(lab.Publication() & project_key
+                              ).fetch('publication').tolist() or None
     )
 
 
@@ -53,9 +54,7 @@ def element_lab_to_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
                              **elementlab_nwb_dict(
                                 lab_key=key1,
                                 project_key=key2,
-                                protocol_key=key3,
-                                )
-                            )
+                                protocol_key=key3))
 
     :param lab_key: Key specifying one entry in element_lab.lab.Lab
     :param project_key: Key specifying one entry in element_lab.lab.Project

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -44,12 +44,6 @@ def project_to_nwb_dict(project_key=None):
                 if 'surgery' in proj_info else ''),
             virus=(proj_info['virus']
                 if 'virus' in proj_info else '')
-
-            ## AttributeError: 'str' object has no attribute 'parent'
-            ## Broz: I thought these were notes about the stimulus?
-            ##    Error indicates trying to process stim file itself?
-            # stimulus=(list(proj_info['stimulus'])
-            #     if 'stimulus' in proj_info else [])
         )
     else: return {}
 

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -41,12 +41,8 @@ def protocol_to_nwb_dict(protocol_key):
     """
     prot_info = (lab.Protocol & protocol_key).fetch1()
     return dict(
-        # data_collection='',
-        protocol=(prot_info['protocol']
-                  if 'protocol' in prot_info else ''),
-        notes=(prot_info['protocol_description']
-               if 'project_description' in prot_info else '')
-    )
+        protocol=prot_info.get('protocol', ''),
+        notes=prot_info.get('protocol_description', ''))
 
 
 def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
@@ -78,11 +74,11 @@ def elementlab_nwb_dict(lab_key=None, project_key=None, protocol_key=None):
 
     elem_info = dict()
     if lab_key:
-        elem_info.update(**lab_to_nwb_dict(lab_key))
+        elem_info.update(lab_to_nwb_dict(lab_key))
     if project_key:
-        elem_info.update(**project_to_nwb_dict(project_key))
+        elem_info.update(project_to_nwb_dict(project_key))
     if protocol_key:
-        elem_info.update(**protocol_to_nwb_dict(protocol_key))
+        elem_info.update(protocol_to_nwb_dict(protocol_key))
 
     # Drop blank entries
     elem_info = {k: v for k, v in elem_info.items() if v}

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -18,7 +18,7 @@ def lab_to_nwb_dict(lab_key=None):
     else: return {}
 
 
-def proj_to_nwb_dict(project_key=None):
+def project_to_nwb_dict(project_key=None):
     """
     Generate a dictionary object containing relevant project information
         (e.g., experimental description, related publications, etc.).
@@ -54,7 +54,7 @@ def proj_to_nwb_dict(project_key=None):
     else: return {}
 
 
-def prot_to_nwb_dict(protocol_key=None):
+def protocol_to_nwb_dict(protocol_key=None):
     """
     Generate a dictionary object containing all protocol title and notes.
     :param protocol_key: Key specifying one entry in element_lab.lab.Protocol
@@ -71,14 +71,14 @@ def prot_to_nwb_dict(protocol_key=None):
         )
     else: return {}
 
-def elemlab_to_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
+def elementlab_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
     """
     Generate a dictionary object containing all relevant lab information used when
         generating an NWB file at the session level. All parameters optional.
     Use: mynwbfile = NWBfile(identifier="your identifier",
                              session_description="your description",
                              session_start_time=session_datetime,
-                             elemlab_to_nwb_dict(lab_key=key1,project_key=key2,protocol_key=key3))
+                             elementlab_nwb_dict(lab_key=key1,project_key=key2,protocol_key=key3))
     Note: The lab, project and protocol keys should specify one of their respective types.
 
     :param lab_key: Key specifying one entry in element_lab.lab.Lab
@@ -96,8 +96,8 @@ def elemlab_to_nwb_dict(lab_key=None,project_key=None,protocol_key=None):
 
     elem_info=dict(
         lab_to_nwb_dict(lab_key),
-        **proj_to_nwb_dict(project_key),
-        **prot_to_nwb_dict(protocol_key)
+        **project_to_nwb_dict(project_key),
+        **protocol_to_nwb_dict(protocol_key)
         )
 
     for k in list(elem_info): # Drop blank entries

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from element_lab import lab
 
 def lab_to_nwb_dict(lab_key=None):
     """

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -1,0 +1,31 @@
+import numpy as np
+from datetime import datetime
+from dateutil.tz import tzlocal
+from pynwb import NWBFile
+
+from element_lab import lab
+
+def lab_to_nwb(lab_key):
+  lab_query = lab.Lab & lab_key
+    lab_query = lab_query.join(lab.Lab.Protocol, left=True)
+    lab_query = lab_query.join(lab.Lab.Project, left=True)
+  lab_info = lab.query.fetch1()
+
+  return NWBFile(
+    data_collection='',
+    experiment_description=lab_info.pop('project_description'),
+    institution=lab_info.pop('institution'),
+    keywords=list(lab.Project.keywords.fetch()),
+    lab=lab_info.pop('lab_name'),
+    notes=lab_info.pop('protocol_description'),
+    pharmacology=lab_info.pop('pharmacology'),
+    protocol=lab_info.pop('protocol'),
+    related_publications=list(lab.Project.publication.fetch()),
+    session_id='', # why is NWB asking for this at this level?
+    slices=lab_info.pop('slices'),
+    souce_script=lab_info.pop('repositoryurl'),
+    file_name=lab_info.pop('repositoryname'),
+    stimulus=lab_info.pop('stimulus'),
+    surgery=lab_info.pop('surgery'),
+    virus=lab_info.pop('virus')
+    )

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -35,8 +35,7 @@ def project_to_nwb_dict(project_key=None):
             pharmacology=proj_info.get('pharmacology', ''),
             related_publications=proj_pubs,
             slices=proj_info.get('slices', ''),
-            source_script=(proj_info['repositoryurl']
-                if 'repositoryurl' in proj_info else ''),
+            source_script=proj_info.get('repositoryurl', ''),
             surgery=(proj_info['surgery']
                 if 'surgery' in proj_info else ''),
             virus=(proj_info['virus']

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -36,8 +36,7 @@ def project_to_nwb_dict(project_key=None):
             related_publications=proj_pubs,
             slices=proj_info.get('slices', ''),
             source_script=proj_info.get('repositoryurl', ''),
-            surgery=(proj_info['surgery']
-                if 'surgery' in proj_info else ''),
+            surgery=(proj_info.get('surgery', ''),
             virus=(proj_info['virus']
                 if 'virus' in proj_info else '')
         )

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -34,8 +34,7 @@ def project_to_nwb_dict(project_key=None):
             keywords=proj_keyw,
             pharmacology=proj_info.get('pharmacology', ''),
             related_publications=proj_pubs,
-            slices=(proj_info['slices']
-                if 'slices' in proj_info else ''),
+            slices=proj_info.get('slices', ''),
             source_script=(proj_info['repositoryurl']
                 if 'repositoryurl' in proj_info else ''),
             surgery=(proj_info['surgery']

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -37,8 +37,7 @@ def project_to_nwb_dict(project_key=None):
             slices=proj_info.get('slices', ''),
             source_script=proj_info.get('repositoryurl', ''),
             surgery=(proj_info.get('surgery', ''),
-            virus=(proj_info['virus']
-                if 'virus' in proj_info else '')
+            virus=proj_info.get('virus', '')
         )
     else: return {}
 

--- a/element_lab/export/nwb.py
+++ b/element_lab/export/nwb.py
@@ -30,8 +30,7 @@ def project_to_nwb_dict(project_key=None):
         proj_keyw = (lab.Project.Keywords() & project_key).fetch('keyword').tolist()
         proj_pubs = (lab.Project.Publication() & project_key).fetch('publication').tolist()
         return dict(
-            experiment_description=(proj_info['project_description']
-                if 'project_description' in proj_info else ''),
+            experiment_description=(proj_info.get('project_description', ''),
             keywords=proj_keyw,
             pharmacology=(proj_info['pharmacology']
                 if 'pharmacology' in proj_info else ''),

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -107,12 +107,12 @@ class Project(dj.Lookup):
         publication: varchar(256)
         """
 
-    class Sourcecode(dj.Part):
+    class SourceCode(dj.Part):
         definition = """
-        # URL to source code for replication
-        # included as source_script in NWB export
         -> master
-        codeurl: varchar(256)
+        repository_url                : varchar(256)   # URL to source code for replication
+        ---
+        repository_name=''       : varchar(32)
         """
 
 @schema

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -6,11 +6,15 @@ schema = dj.Schema()
 def activate(schema_name, create_schema=True, create_tables=True):
     """
     activate(schema_name, create_schema=True, create_tables=True)
-        :param schema_name: schema name on the database server to activate the `lab` element
-        :param create_schema: when True (default), create schema in the database if it does not yet exist.
-        :param create_tables: when True (default), create tables in the database if they do not yet exist.
+        :param schema_name: schema name on the database server to activate the
+                            `lab` element
+        :param create_schema: when True (default), create schema in the
+                              database if it does not yet exist.
+        :param create_tables: when True (default), create tables in the
+                              database if they do not yet exist.
     """
-    schema.activate(schema_name, create_schema=create_schema, create_tables=create_tables)
+    schema.activate(schema_name, create_schema=create_schema,
+                    create_tables=create_tables)
 
 
 @schema
@@ -23,6 +27,7 @@ class Lab(dj.Lookup):
     address         : varchar(255)
     time_zone       : varchar(64)
     """
+
 
 @schema
 class Location(dj.Lookup):
@@ -79,18 +84,13 @@ class Protocol(dj.Lookup):
     protocol_description='' : varchar(255)
     """
 
+
 @schema
 class Project(dj.Lookup):
     definition = """
     project                 : varchar(32)
     ---
     project_description=''  : varchar(1024)
-    # Below included for archival export (e.g., NWB)
-    pharmacology = ''       : varchar(2048) # Drugs used, how/when administered
-    viruses=''              : varchar(2048) # ID, source, date made, injection loc, volume
-    slices=''               : varchar(2048) # If slicing, preparation thickness, orientation, temperature, and bath solution
-    stimulus=''             : varchar(2048) # Generation method, how/when/where presented
-    surgery=''              : varchar(2048) # Description of surger(y/ies), who performed, when relative to other events
     """
 
     class Keywords(dj.Part):
@@ -110,10 +110,11 @@ class Project(dj.Lookup):
     class SourceCode(dj.Part):
         definition = """
         -> master
-        repository_url                : varchar(256)   # URL to source code for replication
+        repository_url     : varchar(256) # URL to source code for replication
         ---
-        repository_name=''       : varchar(32)
+        repository_name='' : varchar(32)
         """
+
 
 @schema
 class ProjectUser(dj.Manual):
@@ -127,9 +128,9 @@ class ProjectUser(dj.Manual):
 class Source(dj.Lookup):
     definition = """
     # source or supplier of animals
-    source             : varchar(32)    # abbreviated source name
+    source                : varchar(32)  # abbreviated source name
     ---
-    source_name        : varchar(255)
-    contact_details='' : varchar(255)
-    source_description=''     : varchar(255)
+    source_name           : varchar(255)
+    contact_details=''    : varchar(255)
+    source_description='' : varchar(255)
     """

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -16,7 +16,7 @@ def activate(schema_name, create_schema=True, create_tables=True):
 @schema
 class Lab(dj.Lookup):
     definition = """
-    lab             : varchar(24)  #  Abbreviated lab name 
+    lab             : varchar(24)    #  Abbreviated lab name
     ---
     lab_name        : varchar(255)   # full lab name
     institution     : varchar(255)
@@ -77,7 +77,7 @@ class Protocol(dj.Lookup):
     protocol                : varchar(16)
     ---
     -> ProtocolType
-    protocol_description=''        : varchar(255)
+    protocol_description='' : varchar(255)
     """
 
 
@@ -86,8 +86,37 @@ class Project(dj.Lookup):
     definition = """
     project                 : varchar(32)
     ---
-    project_description=''         : varchar(1024)
+    project_description=''  : varchar(1024)
+    # Below included for archival export (e.g., NWB)
+    repositoryurl=''        : varchar(256) # URL to code for replication
+    repositoryname=''       : varchar(32)  # name of repository
+    pharmacology = ''       : varchar(2048) # Drugs used, how/when administered
+    viruses=''              : varchar(2048) # ID, source, date made, injection loc, volume
+    slices=''               : varchar(2048) # If slicing, preparation thickness, orientation, temperature, and bath solution
+    stimulus=''             : varchar(2048) # Generation method, how/when/where presented
+    surgery=:''             : varchar(2048) # Description of surger(y/ies), who performed, when relative to other events
     """
+
+    class Keywords(dj.Part):
+        definition = """
+        # Project keywords, exported dataset meta info
+        -> master
+        keyword='' : varchar(32)
+        """
+
+    class Publication(dj.Part):
+        definition = """
+        # Project's resulting publications
+        -> master
+        publication='' : varchar(256)
+        """
+
+    class Sourcecode(dj.Part):
+        definition = """
+        # URL to source code for replication
+        # included as source_script in NWB export
+        -> master
+        """
 
 
 @schema

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -24,11 +24,6 @@ class Lab(dj.Lookup):
     time_zone       : varchar(64)
     """
 
-    def make_nwb(cls, lab_key):
-        from .export import lab_to_nwb
-        return lab_to_nwb(lab_key)
-
-
 @schema
 class Location(dj.Lookup):
     definition = """

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -84,14 +84,9 @@ class Protocol(dj.Lookup):
     protocol_description='' : varchar(255)
     """
 
-    def make_nwb(cls, lab_key):
-        from .export import lab_to_nwb
-        return lab_to_nwb(lab_key)
-
 @schema
 class Project(dj.Lookup):
     definition = """
-    -> Lab
     project                 : varchar(32)
     ---
     project_description=''  : varchar(1024)
@@ -148,3 +143,28 @@ class Source(dj.Lookup):
     contact_details='' : varchar(255)
     source_description=''     : varchar(255)
     """
+
+@schema
+class Equipment(dj.Manual):
+    definition = """
+    # Equipment information
+    equipment_id: varchar(16)
+    ---
+    manufacturer: varchar(32)
+    description: varchar(255)
+    """
+
+    class EphysEquipment(dj.Part):
+        definition = """
+        ->master # Needs more here
+        """
+
+    class CaImgEquipment(dj.Part):
+        definition = """
+        ->master # Needs more here
+        caimg_equip_type: varchar(32)
+        ---
+        caimg_equip_descrip: varchar(255)
+        excitation_lambda: float
+        emission_lambda:   float
+        """

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -86,8 +86,6 @@ class Project(dj.Lookup):
     ---
     project_description=''  : varchar(1024)
     # Below included for archival export (e.g., NWB)
-    repositoryurl=''        : varchar(256) # URL to code for replication
-    repositoryname=''       : varchar(32)  # name of repository
     pharmacology = ''       : varchar(2048) # Drugs used, how/when administered
     viruses=''              : varchar(2048) # ID, source, date made, injection loc, volume
     slices=''               : varchar(2048) # If slicing, preparation thickness, orientation, temperature, and bath solution

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -25,7 +25,7 @@ class Lab(dj.Lookup):
     lab_name        : varchar(255)   # full lab name
     institution     : varchar(255)
     address         : varchar(255)
-    time_zone       : varchar(64)
+    time_zone       : varchar(64)    # 'UTC±X' format for NWB export
     """
 
 

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -117,9 +117,6 @@ class Project(dj.Lookup):
         codeurl: varchar(256)
         """
 
-
-
-
 @schema
 class ProjectUser(dj.Manual):
     definition = """
@@ -138,28 +135,3 @@ class Source(dj.Lookup):
     contact_details='' : varchar(255)
     source_description=''     : varchar(255)
     """
-
-@schema
-class Equipment(dj.Manual):
-    definition = """
-    # Equipment information
-    equipment_id: varchar(16)
-    ---
-    manufacturer: varchar(32)
-    description: varchar(255)
-    """
-
-    class EphysEquipment(dj.Part):
-        definition = """
-        ->master # Needs more here
-        """
-
-    class CaImgEquipment(dj.Part):
-        definition = """
-        ->master # Needs more here
-        caimg_equip_type: varchar(32)
-        ---
-        caimg_equip_descrip: varchar(255)
-        excitation_lambda: float
-        emission_lambda:   float
-        """

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -94,7 +94,7 @@ class Project(dj.Lookup):
     """
 
 
-class Keywords(dj.Manual):
+class ProjectKeywords(dj.Manual):
     definition = """
     # Project keywords, exported dataset meta info
     -> Project
@@ -102,7 +102,7 @@ class Keywords(dj.Manual):
     """
 
 
-class Publication(dj.Manual):
+class ProjectPublication(dj.Manual):
     definition = """
     # Project's resulting publications
     -> Project
@@ -110,7 +110,7 @@ class Publication(dj.Manual):
     """
 
 
-class SourceCode(dj.Manual):
+class ProjectSourceCode(dj.Manual):
     definition = """
     # URL to source code for replication
     -> Project

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -84,6 +84,7 @@ class Protocol(dj.Lookup):
 @schema
 class Project(dj.Lookup):
     definition = """
+    -> Lab
     project                 : varchar(32)
     ---
     project_description=''  : varchar(1024)
@@ -117,6 +118,10 @@ class Project(dj.Lookup):
         # included as source_script in NWB export
         -> master
         """
+
+    def make_nwb(cls, lab_key):
+        from .export import lab_to_nwb
+        return lab_to_nwb(lab_key)
 
 
 @schema

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -24,6 +24,10 @@ class Lab(dj.Lookup):
     time_zone       : varchar(64)
     """
 
+    def make_nwb(cls, lab_key):
+        from .export import lab_to_nwb
+        return lab_to_nwb(lab_key)
+
 
 @schema
 class Location(dj.Lookup):
@@ -80,6 +84,9 @@ class Protocol(dj.Lookup):
     protocol_description='' : varchar(255)
     """
 
+    def make_nwb(cls, lab_key):
+        from .export import lab_to_nwb
+        return lab_to_nwb(lab_key)
 
 @schema
 class Project(dj.Lookup):
@@ -95,7 +102,7 @@ class Project(dj.Lookup):
     viruses=''              : varchar(2048) # ID, source, date made, injection loc, volume
     slices=''               : varchar(2048) # If slicing, preparation thickness, orientation, temperature, and bath solution
     stimulus=''             : varchar(2048) # Generation method, how/when/where presented
-    surgery=:''             : varchar(2048) # Description of surger(y/ies), who performed, when relative to other events
+    surgery=''              : varchar(2048) # Description of surger(y/ies), who performed, when relative to other events
     """
 
     class Keywords(dj.Part):
@@ -117,11 +124,10 @@ class Project(dj.Lookup):
         # URL to source code for replication
         # included as source_script in NWB export
         -> master
+        codeurl: varchar(256)
         """
 
-    def make_nwb(cls, lab_key):
-        from .export import lab_to_nwb
-        return lab_to_nwb(lab_key)
+
 
 
 @schema

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -109,7 +109,7 @@ class Project(dj.Lookup):
         definition = """
         # Project's resulting publications
         -> master
-        publication='' : varchar(256)
+        publication: varchar(256)
         """
 
     class Sourcecode(dj.Part):

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -102,7 +102,7 @@ class Project(dj.Lookup):
         definition = """
         # Project keywords, exported dataset meta info
         -> master
-        keyword='' : varchar(32)
+        keyword: varchar(32)
         """
 
     class Publication(dj.Part):

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -93,27 +93,31 @@ class Project(dj.Lookup):
     project_description=''  : varchar(1024)
     """
 
-    class Keywords(dj.Part):
-        definition = """
-        # Project keywords, exported dataset meta info
-        -> master
-        keyword: varchar(32)
-        """
 
-    class Publication(dj.Part):
-        definition = """
-        # Project's resulting publications
-        -> master
-        publication: varchar(256)
-        """
+class Keywords(dj.Manual):
+    definition = """
+    # Project keywords, exported dataset meta info
+    -> Project
+    keyword: varchar(32)
+    """
 
-    class SourceCode(dj.Part):
-        definition = """
-        -> master
-        repository_url     : varchar(256) # URL to source code for replication
-        ---
-        repository_name='' : varchar(32)
-        """
+
+class Publication(dj.Manual):
+    definition = """
+    # Project's resulting publications
+    -> Project
+    publication: varchar(256)
+    """
+
+
+class SourceCode(dj.Manual):
+    definition = """
+    # URL to source code for replication
+    -> Project
+    repository_url     : varchar(256)
+    ---
+    repository_name='' : varchar(32)
+    """
 
 
 @schema

--- a/element_lab/version.py
+++ b/element_lab/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = '0.1.0b0'
+__version__ = '0.1.0b1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 datajoint>=0.13.0
+pynwb==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 datajoint>=0.13.0
-pynwb==1.4.0
+pynwb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 datajoint>=0.13.0
-pynwb
+pynwb==1.4.0

--- a/temp.py
+++ b/temp.py
@@ -1,0 +1,2 @@
+import datajoint as dj
+

--- a/temp.py
+++ b/temp.py
@@ -1,2 +1,0 @@
-import datajoint as dj
-


### PR DESCRIPTION
Expanding element-lab for nwb export features, see corresponding PR for [workflow-animal/session](https://github.com/datajoint/workflow-animal/pull/9)

- adding optional foreign keys to support components of nwb export
- added lab/project/protocol to dict functions for populating NWB for users with `element-lab` but not `element-session`