### PR TITLE
Fix: GitHub Actions build failed for PyPI release #26

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Compile image
         run: |
           export PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
-          export PKG_VERSION=$(cat ${PKG_NAME}/version.py | awk -F\' '/__version__ = / {print $2}')
+          export PKG_VERSION=$(cat ${PKG_NAME}/version.py | awk -F\" '/__version__ = / {print $2}')
           export HOST_UID=$(id -u)
           docker-compose -f docker-compose-build.yaml up --exit-code-from element --build
           IMAGE=$(docker images --filter "reference=datajoint/${PKG_NAME}*" \


### PR DESCRIPTION
Fixed: python black converted single quote to double quote causes PKG_VERSION parsing failure

Close #26 