### PR TITLE
increase `user_role` length to 24

### DIFF
--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -60,7 +60,7 @@ class Location(dj.Lookup):
 @schema
 class UserRole(dj.Lookup):
     definition = """
-    user_role       : varchar(16)
+    user_role       : varchar(24)
     """
 
 


### PR DESCRIPTION
`user_role` with varchar(16) is just a tad too short - suggest increasing to 24
(to at least fit the string `Research Scientist`)

`UserRole` is used mostly for secondary attribute, so large varchar is not a huge concern.