### PR TITLE
Add `Device` table

### DIFF
--- a/.github/workflows/u24_element_release_call.yml
+++ b/.github/workflows/u24_element_release_call.yml
@@ -17,7 +17,6 @@ jobs:
     secrets:
       TWINE_USERNAME: ${{secrets.TWINE_TEST_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_TEST_PASSWORD}}
-      GOOGLE_ANALYTICS_KEY: ${{secrets.GOOGLE_ANALYTICS_KEY}}
   call_u24_elements_release_alpine:
     if: >-
       github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'datajoint' && !contains(github.event.workflow_run.head_branch, 'test')
@@ -27,4 +26,3 @@ jobs:
     secrets:
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-      GOOGLE_ANALYTICS_KEY: ${{secrets.GOOGLE_ANALYTICS_KEY}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 ## [0.3.0] - 2023-06-02
 
 + Add - `Device` table to `lab` schema
++ Update - Docs configuration to remove Google Analytics key and add Markdown extensions
 
 ## [0.2.2] - 2023-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.0] - 2023-06-02
+
++ Add - `Device` table to `lab` schema
+
 ## [0.2.0] - 2022-01-20
 
 + Add - `project` schema for project/study/experiment related tables
@@ -29,6 +33,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - GitHub Action release process
 + Add - `lab` schema
 
+[0.3.0]: https://github.com/datajoint/element-lab/releases/tag/0.3.0
 [0.2.0]: https://github.com/datajoint/element-lab/releases/tag/0.2.0
 [0.1.2]: https://github.com/datajoint/element-lab/releases/tag/0.1.2
 [0.1.1]: https://github.com/datajoint/element-lab/releases/tag/0.1.1

--- a/docs/.docker/pip_requirements.txt
+++ b/docs/.docker/pip_requirements.txt
@@ -8,3 +8,5 @@ mkdocs-gen-files
 mkdocs-literate-nav
 mkdocs-exclude-search
 mkdocs-markdownextradata-plugin
+mkdocs-jupyter
+mkdocs-section-index

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -13,7 +13,6 @@ services:
       - PACKAGE
       - UPSTREAM_REPO
       - MODE
-      - GOOGLE_ANALYTICS_KEY
       - PATCH_VERSION
     volumes:
       - ../docs:/main/docs

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -42,17 +42,14 @@ nav:
 #     UPSTREAM_REPO=https://github.com/datajoint/element-{ELEMENT}.git \
 #     HOST_UID=$(id -u) docker compose -f docs/docker-compose.yaml up --build
 #     ```
-# 02. Site analytics depend on a local environment variable GOOGLE_ANALYTICS_KEY
-#     You can find this in LastPass or declare with any string to suppress errors
-# 03. The API section will pull docstrings.
+# 02. The API section will pull docstrings.
 #     A. Follow google styleguide e.g.,
 #        https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
 #        With typing suggestions: https://docs.python.org/3/library/typing.html
 #     B. To pull a specific workflow fork, change ./docs/src/api/make_pages.py#L19
-# 04. To see your fork of the workflow-{element} in this render, change the
+# 03. To see your fork of the workflow-{element} in this render, change the
 #     URL in ./docs/src/api/make_pages.py#L19 to your fork.
-# 05. For redirecting options For redirect options, see 'redirects' below.
-# 06. To deploy this site on your fork,
+# 04. To deploy this site on your fork,
 #     A. declare a branch called gh-pages
 #     B. go to the your fork > settings > pages
 #     C. direct pages to render from the gh-pages branch at root
@@ -87,9 +84,6 @@ theme:
 plugins:
   - markdownextradata: {}
   - search
-  # - redirects: # OPTIONAL REDIRECTS
-  #     redirect_maps:
-  #       "index.md": "getting_started.md"
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -127,7 +121,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - footnotes
-
+  - pymdownx.magiclink # Displays bare URLs as links
+  - pymdownx.tasklist: # Renders check boxes in tasks lists
+      custom_checkbox: true
 extra:
   PATCH_VERSION: !ENV PATCH_VERSION
   generator: false # Disable watermark

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -131,9 +131,6 @@ markdown_extensions:
 extra:
   PATCH_VERSION: !ENV PATCH_VERSION
   generator: false # Disable watermark
-  analytics:
-    provider: google
-    property: !ENV GOOGLE_ANALYTICS_KEY
   version:
     provider: mike
   social:

--- a/element_lab/lab.py
+++ b/element_lab/lab.py
@@ -272,3 +272,21 @@ class Source(dj.Lookup):
     contact_details=''    : varchar(255)
     source_description='' : varchar(255)
     """
+
+
+@schema
+class Device(dj.Lookup):
+    """Devices within the lab.
+
+    Attributes:
+        device ( varchar(32) ): Device short name.
+        modality ( varchar(64) ): Modality for which this device is used.
+        description ( varchar(256) ): Optional. Description of the device.
+    """
+
+    definition = """
+    device             : varchar(32)
+    ---
+    modality           : varchar(64)
+    description=''     : varchar(256)
+    """

--- a/element_lab/version.py
+++ b/element_lab/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Description
- Currently, a user must declare an `Equipment` or `Device` table in the corresponding `workflow`.  For example:
  - [workflow-miniscope reference schema](https://github.com/datajoint/workflow-miniscope/blob/main/workflow_miniscope/reference.py)
  - [workflow-calcium-imaging reference schema](https://github.com/datajoint/workflow-calcium-imaging/blob/main/workflow_calcium_imaging/reference.py)
  - [workflow-zstack reference schema](https://github.com/datajoint/workflow-zstack/blob/main/workflow_zstack/reference.py)
- The updates proposed here would eliminate the requirement to declare an `Equipment` or `Device` table in each user's workflow

## Changes
- [x] Add `Device` table to `lab` schema
- [x] Update docs configuration to remove Google Analytics key and add Markdown extensions